### PR TITLE
OpenAPI Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ $response = $dispatcher->dispatch(ServerRequestFactory::fromGlobals());
 * [TrailingSlash](https://github.com/middlewares/trailing-slash)
 * [Www](https://github.com/middlewares/www)
 
+### Validation
+
+* [OpenAPI](https://github.com/thephpleague/openapi-psr7-validator)
+
 ### Others
 
 * [Proxy](https://github.com/middlewares/proxy)


### PR DESCRIPTION
This has PSR7 in the name but supports PSR15 too.

```php
use League\OpenAPIValidation\PSR15\ValidationMiddlewareBuilder;

$yamlFile = './api/openapi.yaml';
$psr15Middleware = (new ValidationMiddlewareBuilder->fromYamlFile($yamlFile)->getValidationMiddleware();
```