### PR TITLE
Move Debugbar before Negotiation middleware in the Dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ $dispatcher = new Dispatcher([
     //Add cache expiration headers
     new Middlewares\Expires(),
 
+    //Add the php debugbar
+    new Middlewares\Debugbar(),
+
     //Negotiate the content-type
     new Middlewares\ContentType(),
 
@@ -76,9 +79,6 @@ $dispatcher = new Dispatcher([
     //Create and save a session in '_session' attribute
     (new Middlewares\AuraSession())
         ->attribute('_session'),
-
-    //Add the php debugbar
-    new Middlewares\Debugbar(),
 
     //Handle the route
     new Middlewares\RequestHandler(),


### PR DESCRIPTION
Hi,

Debugbar depends on Content-Type header which is generated by Negotation middleware when middlewares are being traversed 
from the inside out, so Debugbar should go before Negotiation in the Dispatcher.

Thanks for your amazing work and helping me in the past @oscarotero ! :raised_hands: 